### PR TITLE
Add CloudApp free pro account in freebies for students

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A collection of awesome useful and awesome links, resources and shiny things for
 * [Free for dev](https://free-for.dev/) This is a list of software (SaaS, PaaS, IaaS, etc.) and other offerings that have free tiers for developers.
 * [Tableau for Students](https://www.tableau.com/academic/students) Get a free license to Tableau's data visualization software!
 * [Shodan Membership](https://help.shodan.io/the-basics/account-faq) Get a free membership + Educational API plan for the [Shodan](https://www.shodan.io/) search engine 
+* [CloudApp](https://www.getcloudapp.com/education) Cloud App is an instant cloud based GIF, screenshots, and video sharing product for collaboration. Students get a free pro account. 
 
 ## Opportunities and international exchange programs
 * [Aiesec](https://aiesec.org/) Find international internships, volunteering opportunities.


### PR DESCRIPTION
## Summary:
I added CloudApp free pro account for students in the freebies for students section. Cloud App is an instant cloud-based GIF, screenshots, and video sharing product for collaboration

Added:

- [CloudApp](https://www.getcloudapp.com/education)
